### PR TITLE
Remove steal.production.js from the bundled glob

### DIFF
--- a/default/templates/cordovaOptions.ejs
+++ b/default/templates/cordovaOptions.ejs
@@ -5,9 +5,7 @@ var cordovaOptions = {
   platforms: <%- JSON.stringify(platforms) %>,
   plugins: ["cordova-plugin-transport-security"],
   index: __dirname + "/production.html",
-  glob: [
-    "node_modules/steal/steal.production.js"
-  ]
+  glob: []
 };
 
 var stealCordova = require("steal-cordova")(cordovaOptions);


### PR DESCRIPTION
This removes the steal.production.js from node_modules. In Steal 1.0
this is handled by the build process itself.