### PR TITLE
Add can-route mappings for the build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
-  - "6"
-  - "7"
+  - "8"
+  - "10"

--- a/default/index.js
+++ b/default/index.js
@@ -8,6 +8,7 @@ var is = {
   linux: os.platform() === 'linux',
   windows: os.platform() === 'win32'
 };
+var addRoutingMap = require('donejs-generator-common/routing').addRoutingMap;
 
 module.exports = Generator.extend({
   prompting: function () {
@@ -92,6 +93,8 @@ module.exports = Generator.extend({
             ejs.render(commentEndText, context) +
             data.substring(commentEndIndex + commentEndText.length);
         }
+
+        newContent = addRoutingMap(newContent, data);
 
         fs.writeFile(outputBuildjs, newContent, function(){
           buildJsDeferred.resolve();

--- a/default/templates/header.ejs
+++ b/default/templates/header.ejs
@@ -1,7 +1,12 @@
 var stealTools = require("steal-tools");
 
+var buildElectron = process.argv.indexOf("electron") > 0;
+var buildCordova = process.argv.indexOf("cordova") > 0;
+
 var buildPromise = stealTools.build({
-  config: __dirname + "/package.json!npm"
+  map: ((buildElectron || buildCordova) ? {
+    "can-route-pushstate": "can-route-hash"
+  } : {})
 }, {
   bundleAssets: true
 });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "DoneJS"
   ],
   "dependencies": {
+    "donejs-generator-common": "^1.0.5",
     "ejs": "^2.3.4",
     "q": "^1.4.1",
     "yeoman-generator": "^1.1.1"
@@ -36,6 +37,7 @@
     "fs-extra": "^2.1.2",
     "jshint": "^2.8.0",
     "mocha": "^3.2.0",
-    "yeoman-test": "^1.6.0"
+    "yeoman-test": "^1.6.0",
+    "yeoman-assert": "3.1.0"
   }
 }

--- a/test/templates/donejs-cordova-with-map/build.js
+++ b/test/templates/donejs-cordova-with-map/build.js
@@ -1,0 +1,35 @@
+var buildElectron = process.argv.indexOf("electron") > 0;
+var buildCordova = process.argv.indexOf("cordova") > 0;
+
+// generator-donejs + donejs-cordova build.js
+var stealTools = require("steal-tools");
+
+var buildPromise = stealTools.build({
+  map: ((buildElectron || buildCordova) ? {
+    "can-route-pushstate": "can-route-hash"
+  } : {}),
+}, {
+  bundleAssets: true
+});
+
+// options added by `donejs add cordova` - START
+// previous cordova options - START
+var cordovaOptions = {
+  buildDir: "./build/cordova",
+  id: "com.bar.foo.existing",
+  name: "Existing Foo",
+  platforms: ["ios"],
+  plugins: ["cordova-plugin-transport-security"],
+  index: __dirname + "/production.html",
+  glob: [
+    "node_modules/steal/steal.production.js"
+  ]
+};
+
+var stealCordova = require("steal-cordova")(cordovaOptions);
+
+if(buildCordova) {
+  buildPromise.then(stealCordova.build).then(stealCordova.ios.emulate);
+}
+// previous cordova options - END
+// options added by `donejs add cordova` - END


### PR DESCRIPTION
This is a breaking change as it is only compatible with CanJS 5.0. This
maps `can-route-pushstate` to `can-route-hash` when doing a build for
electron.